### PR TITLE
Upgrade Demo_GridView

### DIFF
--- a/Demo_GridView/app/build.gradle
+++ b/Demo_GridView/app/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '27.0.3'
+    compileSdk 33
 
     defaultConfig {
         applicationId "ca.yorku.eecs.mack.demogridview"
-        minSdkVersion 13
-        targetSdkVersion 22
+        minSdk 14
+        targetSdk 33
     }
 
     buildTypes {
@@ -19,5 +18,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:support-v4:22.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 }

--- a/Demo_GridView/app/src/main/AndroidManifest.xml
+++ b/Demo_GridView/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@android:style/Theme.Holo" >
         <activity
             android:name="ca.yorku.eecs.mack.demogridview.DemoGridViewActivity"
-            android:label="@string/app_name" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.VIEW" />

--- a/Demo_GridView/build.gradle
+++ b/Demo_GridView/build.gradle
@@ -1,17 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/Demo_GridView/gradle.properties
+++ b/Demo_GridView/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/Demo_GridView/gradle/wrapper/gradle-wrapper.properties
+++ b/Demo_GridView/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 25 04:50:06 EDT 2019
+#Tue Dec 12 23:17:04 EST 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updates the `Demo_GridView` project to be runnable on download (upgrade to gradle 7.4.2 and SDK 33).

Seems to be a problem recognizing/accessing the image files properly